### PR TITLE
add news alias

### DIFF
--- a/wbooks/babel.config.js
+++ b/wbooks/babel.config.js
@@ -9,7 +9,16 @@ module.exports = {
         extensions: ['.ios.js', '.android.js', '.js', '.jsx', '.ts', '.tsx', '.json'],
         alias: {
           '@app': './src/app',
-          '@constants': './src/constants'
+          '@constants': './src/constants',
+          '@assets': './src/app/assets',
+          '@components': './src/app/components',
+          '@hooks': './src/app/hooks',
+          '@screens': './src/app/screens',
+          '@config': './src/config',
+          '@interfaces': './src/interfaces',
+          '@redux': './src/redux',
+          '@services': './src/services',
+          '@utils': './src/utils'
         }
       }
     ]

--- a/wbooks/tsconfig.json
+++ b/wbooks/tsconfig.json
@@ -57,7 +57,16 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     "paths": {
       "@app/*": ["src/app/*"],
-      "@constants/*": ["src/constants/*"]
+      "@constants/*": ["src/constants/*"],
+      "@assets/*": ["src/app/assets/*"],
+      "@components/*": ["src/app/components/*"],
+      "@hooks/*": ["src/app/hooks/*"],
+      "@screens/*": ["src/app/screens/*"],
+      "@config/*": ["src/config/*"],
+      "@interfaces/*": ["src/interfaces/*"],
+      "@redux/*": ["src/redux/*"],
+      "@services/*": ["src/services/*"],
+      "@utils/*": ["src/utils/*"]
     },
   },
   "include": ["index.d.ts", "src/**/*", "App.test.tsx"],


### PR DESCRIPTION
## Summary

News alias in babel.config.js and tsconfig.json

'@assets' => './src/app/assets'
'@components' => './src/app/components'
'@hooks' => './src/app/hooks'
'@screens' => './src/app/screens'
'@config' => './src/config'
'@interfaces' => './src/interfaces'
'@redux' => './src/redux'
'@services' => './src/services'
'@utils' => './src/utils'

## Screenshots


### Android

#### Galaxy S (or similar)

#### Pixel 2/3 (or similar)

#### Pixel 3XL (or similar)

### iOS

#### iPhone SE (or similar)

#### iPhone 8 (or similar)

#### iPhone 11 (or similar)

## Trello Card

https://trello.com/c/dtbAYGAF/57-n-55-aliases
